### PR TITLE
changes to hybrid for new json threat

### DIFF
--- a/hybridLayer/hybridLayer.py
+++ b/hybridLayer/hybridLayer.py
@@ -128,7 +128,7 @@ class HybridLayer():
     
     def extract_json_threat(self):
         
-        innerLayer_Threats = self.database.execute_query(f"SELECT * FROM hybrid_idps.innerLayerThreats WHERE event_type = 'jsonComprimised'")
+        innerLayer_Threats = self.database.execute_query(f"SELECT * FROM hybrid_idps.innerLayerThreats WHERE event_type = 'jsonCompromised' OR event_type = 'likesInJsonCompromised'")
         if(len(innerLayer_Threats) >0):
 
             outerLayer_Threats = self.database.execute_query(f"SELECT * FROM hybrid_idps.outerLayerThreats WHERE threatName = 'SSH Login'")

--- a/innerLayer/registeredUsers.json
+++ b/innerLayer/registeredUsers.json
@@ -6,7 +6,7 @@
             "email": "a",
             "posts": [
                 {
-                    "postID": "d3pnuzfrk",
+                    "postID": "lzg1wb36u",
                     "username": "a",
                     "postTitle": "",
                     "content": "",
@@ -14,7 +14,7 @@
                         ""
                     ],
                     "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Image_created_with_a_mobile_phone.png/1280px-Image_created_with_a_mobile_phone.png",
-                    "timestamp": "2024-05-08T13:58:00.184Z",
+                    "timestamp": "2024-05-08T14:16:52.515Z",
                     "likes": 0,
                     "comments": []
                 }


### PR DESCRIPTION
Check like mismatch is not repeating itself in the innerLayer threats table now. It will update the JSON to counteract the change and stop the continuous alerts. 